### PR TITLE
[WIP] feat: use separate storage for storing live dependencies

### DIFF
--- a/changelog.d/20250918_123823_mlabeeb03_user_separate_storage_for_livedeps.md
+++ b/changelog.d/20250918_123823_mlabeeb03_user_separate_storage_for_livedeps.md
@@ -1,0 +1,1 @@
+- [Feature] Use a separate storage for storing live dependencies. (by @mlabeeb03)

--- a/tutorlivedeps/patches/openedx-common-settings
+++ b/tutorlivedeps/patches/openedx-common-settings
@@ -1,0 +1,6 @@
+STORAGES["livedeps"] = {
+    "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    "OPTIONS": {
+        "bucket_name": "livedeps",
+    },
+}

--- a/tutorlivedeps/plugin.py
+++ b/tutorlivedeps/plugin.py
@@ -86,8 +86,7 @@ with tempfile.TemporaryDirectory(prefix="tutor-livedeps-") as zip_dir:
     archive_path = shutil.make_archive(base[:-4], format="zip", root_dir=DEPS_DIR)
 
     with open(archive_path, "rb") as f:
-        # TODO Use a separate storage for live dependencies
-        storages["default"].save(DEPS_KEY, File(f))
+        storages["livedeps"].save(DEPS_KEY, File(f))
 '
     """
 

--- a/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
@@ -9,8 +9,7 @@ DEPS_KEY = "deps.zip"
 DEPS_ZIP_PATH = DEPS_DIR[:-4] + DEPS_KEY
 TRIGGER_FILE = "/openedx/live-dependencies/uwsgi_trigger"
 
-# TODO Use a separate storage for live dependencies
-storage = storages["default"]
+storage = storages["livedeps"]
 
 while True:
     if storage.exists(DEPS_KEY):

--- a/tutorlivedeps/templates/livedeps/build/update_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/update_livedeps.py
@@ -8,8 +8,7 @@ DEPS_DIR = "/openedx/live-dependencies/deps"
 DEPS_KEY = "deps.zip"
 DEPS_ZIP_PATH = DEPS_DIR[:-4] + DEPS_KEY
 
-# TODO Use a separate storage for live dependencies
-storage = storages["default"]
+storage = storages["livedeps"]
 
 if storage.exists(DEPS_KEY):
     if os.path.exists(DEPS_DIR):


### PR DESCRIPTION
The files generated by this plugin should be stored in a separate storage and bucket. This will make it easier and safer to remove all the live dependencies if need be.