### PR TITLE
feat: remove deps.zip file after extracting the packages

### DIFF
--- a/changelog.d/20250919_162612_mlabeeb03_remove_zip_file_after_deps_install.md
+++ b/changelog.d/20250919_162612_mlabeeb03_remove_zip_file_after_deps_install.md
@@ -1,0 +1,1 @@
+- [Improvement] Remove deps.zip file after extracting the packages. (by @mlabeeb03)

--- a/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
@@ -1,12 +1,9 @@
 import datetime
-import os
 import time
 
 from django.core.files.storage import storages
 
-DEPS_DIR = "/openedx/live-dependencies/deps"
 DEPS_KEY = "deps.zip"
-DEPS_ZIP_PATH = DEPS_DIR[:-4] + DEPS_KEY
 TRIGGER_FILE = "/openedx/live-dependencies/uwsgi_trigger"
 
 # TODO Use a separate storage for live dependencies
@@ -15,16 +12,15 @@ storage = storages["default"]
 while True:
     if storage.exists(DEPS_KEY):
         remote_ts = storage.get_modified_time(DEPS_KEY)
+        local_ts = None
+        with open(TRIGGER_FILE, "r") as f:
+            local_ts_str = f.read().strip()
+            if local_ts_str:
+                local_ts = datetime.datetime.fromisoformat(local_ts_str)
 
-        if os.path.exists(DEPS_ZIP_PATH):
-            local_ts = os.path.getmtime(DEPS_ZIP_PATH)
-            local_ts = datetime.datetime.fromtimestamp(
-                local_ts, tz=datetime.timezone.utc
-            )
-
-            if local_ts < remote_ts:
-                with open(TRIGGER_FILE, "a"):
-                    os.utime(TRIGGER_FILE, None)
-    # TODO What happens if download takes more than 10 seconds?
-    # This could keep initiating a reload in a loop.
+        if local_ts is None or local_ts < remote_ts:
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            with open(TRIGGER_FILE, "w") as f:
+                # Writing to the TRIGGER_FILE will cause uWSGI to reload the app
+                f.write(now.isoformat())
     time.sleep(10)

--- a/tutorlivedeps/templates/livedeps/build/update_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/update_livedeps.py
@@ -21,3 +21,5 @@ if storage.exists(DEPS_KEY):
 
     with zipfile.ZipFile(DEPS_ZIP_PATH, "r") as zip_ref:
         zip_ref.extractall(DEPS_DIR)
+
+    os.remove(DEPS_ZIP_PATH)


### PR DESCRIPTION
Remove the deps.zip file to save storage inside the container. Store the time the packages were last fatched in the trigger file and read it from the trigger file instead of checking the creation date of the deps.zip file.