### PR TITLE
feat: use uwsgi cron to run monitor script and add a last_update_timestamp file

### DIFF
--- a/changelog.d/20250919_225935_mlabeeb03_use_cron_decorator.md
+++ b/changelog.d/20250919_225935_mlabeeb03_use_cron_decorator.md
@@ -1,0 +1,2 @@
+- [Improvement] Use uwsgi cron instead of a daemon to run monitor_livedeps.py script. (by @mlabeeb03)
+- [Improvement] Use the last_update_timestamp file to check for the local timestamp of dependencies. (by @mlabeeb03)

--- a/tutorlivedeps/patches/openedx-dockerfile-final
+++ b/tutorlivedeps/patches/openedx-dockerfile-final
@@ -1,8 +1,8 @@
-# Set the PYTHONPATH to include the live dependencies folder
+# Set the PYTHONPATH to include the folder where we put live dependencies
 ENV PYTHONPATH=/openedx/live-dependencies/deps/lib/python3.11/site-packages
 
-# Copy live dependencies scripts and trigger file
 RUN mkdir -p /openedx/live-dependencies
 RUN touch /openedx/live-dependencies/uwsgi_trigger
+RUN touch /openedx/live-dependencies/last_update_timestamp
 COPY --chown=app:app settings/livedeps/build/monitor_livedeps.py /openedx/live-dependencies/
 COPY --chown=app:app settings/livedeps/build/update_livedeps.py /openedx/live-dependencies/

--- a/tutorlivedeps/patches/uwsgi-config
+++ b/tutorlivedeps/patches/uwsgi-config
@@ -1,6 +1,8 @@
-# Run a daemon to detects changes in live dependencies zip file and triggers reloads
-attach-daemon = python /openedx/live-dependencies/monitor_livedeps.py
+# Run a cron job every minute that checks if live dependencies zip file has changed
+unique-cron = -1 -1 -1 -1 -1 python /openedx/live-dependencies/monitor_livedeps.py
+
 # This file is touched by the monitor_livedeps.py script to initiate a reload
 touch-reload = /openedx/live-dependencies/uwsgi_trigger
-# This script downloads persistent packages on server starts/reload
+
+# This script is executed every time the uwsgi server starts/restarts
 exec-asap = python /openedx/live-dependencies/update_livedeps.py

--- a/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
@@ -1,26 +1,34 @@
+"""
+This script is executed as a cron job every minute. It checks if the remote
+`deps.zip` file has been updated. If it has, it touches the  uwsgi_trigger file
+that cause uWSGI to reload the application.
+"""
+
 import datetime
-import time
+import os
 
 from django.core.files.storage import storages
 
 DEPS_KEY = "deps.zip"
 TRIGGER_FILE = "/openedx/live-dependencies/uwsgi_trigger"
+TIMESTAMP_FILE = "/openedx/live-dependencies/last_update_timestamp"
 
-# TODO Use a separate storage for live dependencies
-storage = storages["default"]
 
-while True:
+def main():
+    # TODO Use a separate storage for live dependencies
+    storage = storages["default"]
+
     if storage.exists(DEPS_KEY):
         remote_ts = storage.get_modified_time(DEPS_KEY)
-        local_ts = None
-        with open(TRIGGER_FILE, "r") as f:
+        with open(TIMESTAMP_FILE, "r") as f:
             local_ts_str = f.read().strip()
             if local_ts_str:
                 local_ts = datetime.datetime.fromisoformat(local_ts_str)
 
-        if local_ts is None or local_ts < remote_ts:
-            now = datetime.datetime.now(tz=datetime.timezone.utc)
-            with open(TRIGGER_FILE, "w") as f:
-                # Writing to the TRIGGER_FILE will cause uWSGI to reload the app
-                f.write(now.isoformat())
-    time.sleep(10)
+        if local_ts < remote_ts:
+            with open(TRIGGER_FILE, "a"):
+                os.utime(TRIGGER_FILE, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorlivedeps/templates/livedeps/build/update_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/update_livedeps.py
@@ -1,3 +1,10 @@
+"""
+This script is executed every time the uwsgi server starts/restarts.
+It downloads the live dependencies zip file and extracts it to a specified location.
+It also updates the last_update_timestamp file that is used by the monitor_livedeps.py script.
+"""
+
+import datetime
 import os
 import shutil
 import zipfile
@@ -7,19 +14,35 @@ from django.core.files.storage import storages
 DEPS_DIR = "/openedx/live-dependencies/deps"
 DEPS_KEY = "deps.zip"
 DEPS_ZIP_PATH = DEPS_DIR[:-4] + DEPS_KEY
+TIMESTAMP_FILE = "/openedx/live-dependencies/last_update_timestamp"
 
-# TODO Use a separate storage for live dependencies
-storage = storages["default"]
 
-if storage.exists(DEPS_KEY):
-    if os.path.exists(DEPS_DIR):
-        shutil.rmtree(DEPS_DIR)
-    os.makedirs(DEPS_DIR, exist_ok=True)
+def main():
+    # TODO Use a separate storage for live dependencies
+    storage = storages["default"]
 
-    with storage.open(DEPS_KEY, "rb") as remote_f, open(DEPS_ZIP_PATH, "wb") as local_f:
-        shutil.copyfileobj(remote_f, local_f)
+    if storage.exists(DEPS_KEY):
+        if os.path.exists(DEPS_DIR):
+            shutil.rmtree(DEPS_DIR)
+        os.makedirs(DEPS_DIR, exist_ok=True)
 
-    with zipfile.ZipFile(DEPS_ZIP_PATH, "r") as zip_ref:
-        zip_ref.extractall(DEPS_DIR)
+        with (
+            storage.open(DEPS_KEY, "rb") as remote_f,
+            open(DEPS_ZIP_PATH, "wb") as local_f,
+        ):
+            shutil.copyfileobj(remote_f, local_f)
 
-    os.remove(DEPS_ZIP_PATH)
+        with zipfile.ZipFile(DEPS_ZIP_PATH, "r") as zip_ref:
+            zip_ref.extractall(DEPS_DIR)
+
+        os.remove(DEPS_ZIP_PATH)
+
+    # Store the timestamp of the latest update. If the remote deps.zip file is updated after
+    # this timestamp, the monitor_livedeps.py script will trigger a reload.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    with open(TIMESTAMP_FILE, "w") as f:
+        f.write(now.isoformat())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Use the uwsgi cron option to run the monitor_livedeps script instead of a daemon that runs all the time. To get the local timestamp use the last_update_timestamp file instead of the uwsgi_trigger file..