### PR TITLE
fix: add ability to delete deps.zip file when LIVE_DEPENDENCIES config is empty

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ This plugin depends on the `tutor-minio <https://github.com/overhangio/tutor-min
 
 ``tutor plugins enable livedeps``
 
+Then build the openedx image:
+
+``tutor images build openedx``
+
 
 Configuration
 -------------

--- a/changelog.d/20250922_141635_mlabeeb03_release.md
+++ b/changelog.d/20250922_141635_mlabeeb03_release.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix job runner error when LIVE_DEPENDENCIES config is empty. (by @mlabeeb03)

--- a/tutorlivedeps/plugin.py
+++ b/tutorlivedeps/plugin.py
@@ -68,12 +68,21 @@ def build_live_dependencies(context: Context) -> t.Iterable[tuple[str, str]]:
     all_packages = " ".join(
         package for package in t.cast(list[str], config["LIVE_DEPENDENCIES"])
     )
-
-    script = f"""
-    pip install \
-    --prefix=/openedx/live-dependencies/deps \
-    {all_packages} \
-    && python3 -c '
+    if not all_packages:
+        # Delete the deps.zip file if the LIVE_DEPENDENCIES list is empty
+        script = """
+        python3 -c '
+from django.core.files.storage import storages
+DEPS_KEY = "deps.zip"
+storages["default"].delete(DEPS_KEY)
+'
+        """
+    else:
+        script = f"""
+        pip install \
+        --prefix=/openedx/live-dependencies/deps \
+        {all_packages} \
+        && python3 -c '
 import os, shutil, tempfile
 from django.core.files.storage import storages
 from django.core.files.base import File
@@ -89,7 +98,7 @@ with tempfile.TemporaryDirectory(prefix="tutor-livedeps-") as zip_dir:
         # TODO Use a separate storage for live dependencies
         storages["default"].save(DEPS_KEY, File(f))
 '
-    """
+        """
 
     yield ("lms", script)
 


### PR DESCRIPTION
The job runner would only run successfully if there was an entry in the LIVE_DEPENDENCIES config variable. This meant that atleast one entry should exist in that variable and that it was impossible to delete all of the live dependencies. This change makes it so the runner would delete the deps.zip file if LIVE_DEPENDENCIES config variable is empty.