### PR TITLE
fix: delete the local deps directory after deps.zip is deleted from storage

### DIFF
--- a/changelog.d/20250922_150723_mlabeeb03_delete_deps_dir.md
+++ b/changelog.d/20250922_150723_mlabeeb03_delete_deps_dir.md
@@ -1,0 +1,1 @@
+- [Bugfix] Delete the local deps directory if deps.zip is deleted from storage. (by @mlabeeb03)

--- a/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
+++ b/tutorlivedeps/templates/livedeps/build/monitor_livedeps.py
@@ -6,9 +6,11 @@ that cause uWSGI to reload the application.
 
 import datetime
 import os
+import shutil
 
 from django.core.files.storage import storages
 
+DEPS_DIR = "/openedx/live-dependencies/deps"
 DEPS_KEY = "deps.zip"
 TRIGGER_FILE = "/openedx/live-dependencies/uwsgi_trigger"
 TIMESTAMP_FILE = "/openedx/live-dependencies/last_update_timestamp"
@@ -26,6 +28,12 @@ def main():
                 local_ts = datetime.datetime.fromisoformat(local_ts_str)
 
         if local_ts < remote_ts:
+            with open(TRIGGER_FILE, "a"):
+                os.utime(TRIGGER_FILE, None)
+    else:
+        # If the deps.zip file has been deleted from the storage backend, remove the local deps
+        if os.path.exists(DEPS_DIR):
+            shutil.rmtree(DEPS_DIR)
             with open(TRIGGER_FILE, "a"):
                 os.utime(TRIGGER_FILE, None)
 


### PR DESCRIPTION
The deps directory was not deleted after deps.zip was deleted from storage which caused the dependencies to keep showing in lms and cms. This changes deletes that directory.